### PR TITLE
feat: use `EthTransactionValidator`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5615,7 +5615,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5639,7 +5639,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5670,7 +5670,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5690,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -5704,7 +5704,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "ahash",
  "alloy-chains",
@@ -5777,7 +5777,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5787,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5805,7 +5805,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5825,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -5836,7 +5836,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5864,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -5927,7 +5927,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -5984,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5999,7 +5999,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6025,7 +6025,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6049,7 +6049,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -6139,7 +6139,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6161,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6186,7 +6186,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "futures",
  "pin-project",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6261,7 +6261,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -6288,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6319,7 +6319,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6343,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6382,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6403,7 +6403,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -6444,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "clap",
  "eyre",
@@ -6465,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6499,7 +6499,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6512,7 +6512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6539,7 +6539,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6557,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6590,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6610,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6623,7 +6623,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6641,7 +6641,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6679,7 +6679,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "serde",
  "serde_json",
@@ -6703,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6731,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "bytes",
  "futures",
@@ -6751,7 +6751,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "bindgen",
  "cc",
@@ -6777,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "futures",
  "metrics",
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6811,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6866,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6914,7 +6914,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6929,7 +6929,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -6943,7 +6943,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7052,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7104,7 +7104,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -7142,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7166,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "eyre",
  "http",
@@ -7211,7 +7211,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7224,7 +7224,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7243,7 +7243,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7264,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -7276,7 +7276,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7295,7 +7295,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7305,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7338,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7411,7 +7411,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7435,6 +7435,7 @@ dependencies = [
  "jsonrpsee",
  "parking_lot",
  "rand 0.8.5",
+ "reth-db-common",
  "reth-ethereum",
  "rlimit",
  "thousands",
@@ -7445,7 +7446,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -7458,7 +7459,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7534,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7562,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -7600,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -7619,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7649,7 +7650,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7693,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7737,7 +7738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -7751,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7767,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7817,7 +7818,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7844,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -7858,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -7878,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7890,7 +7891,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7914,7 +7915,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7930,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7948,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7964,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7974,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "clap",
  "eyre",
@@ -7989,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8002,6 +8003,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "paste",
+ "pin-project",
  "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
@@ -8028,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8053,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8079,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -8092,7 +8094,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8117,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8136,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8154,7 +8156,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.6.0"
-source = "git+https://github.com/paradigmxyz/reth.git#575a99fd22e66c25a2a9c1cf2c2457c267ca7860"
+source = "git+https://github.com/0xKitsune/reth.git?rev=b7a3f06e699aeec46a5df2cfbe1daf710f72ca68#b7a3f06e699aeec46a5df2cfbe1daf710f72ca68"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth.git", features = ["full", "test-utils", "cli"] }
+reth-ethereum = { git = "https://github.com/0xKitsune/reth.git", features = ["full", "test-utils", "cli"], rev = "b7a3f06e699aeec46a5df2cfbe1daf710f72ca68" }
+reth-db-common = { git = "https://github.com/0xKitsune/reth.git", rev = "b7a3f06e699aeec46a5df2cfbe1daf710f72ca68" }
 eyre = "0.6"
 alloy-consensus = { version = "1.0.23", default-features = false }
 tokio = { version = "1.44.2", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,6 @@ async fn main() -> eyre::Result<()> {
     let blob_store = InMemoryBlobStore::default();
     let tx_validator =
         EthTransactionValidatorBuilder::new(client.clone()).build(blob_store.clone());
-    // let tx_validator = OkValidator::default();
     let pool: Pool<
         EthTransactionValidator<_, EthPooledTransaction>,
         CoinbaseTipOrdering<EthPooledTransaction>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,11 +96,6 @@ async fn main() -> eyre::Result<()> {
 
     let client = BlockchainProvider::new(factory)?;
 
-    // This block provider implementation is used for testing purposes.
-    // NOTE: This also means that we don't have access to the blockchain and are not able to serve
-    // remote or able to validate transaction against the latest state.
-    // let client = NoopProvider::eth(chain_spec.clone());
-
     let blob_store = InMemoryBlobStore::default();
     let tx_validator =
         EthTransactionValidatorBuilder::new(client.clone()).build(blob_store.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,23 @@ use clap::Parser;
 use dashmap::DashMap;
 use hashbrown::HashSet;
 use jsonrpsee::server::ServerConfigBuilder;
+use reth_db_common::init::init_genesis;
+use reth_ethereum::chainspec::EthChainSpec;
 use reth_ethereum::cli::chainspec::chain_value_parser;
+use reth_ethereum::evm::revm::db::CacheDB;
 use reth_ethereum::evm::revm::primitives::{Address, U256};
+use reth_ethereum::node::EthereumNode;
+use reth_ethereum::node::api::NodeTypesWithDBAdapter;
+use reth_ethereum::pool::test_utils::OkValidator;
 use reth_ethereum::pool::validate::EthTransactionValidatorBuilder;
 use reth_ethereum::pool::{EthTransactionValidator, PoolTransaction, TransactionListenerKind};
-use reth_ethereum::provider::ChangedAccount;
+use reth_ethereum::provider::db::mdbx::DatabaseArguments;
+use reth_ethereum::provider::db::{ClientVersion, DatabaseEnv, init_db, open_db};
+use reth_ethereum::provider::providers::{
+    BlockchainProvider, ProviderFactoryBuilder, StaticFileProvider,
+};
+use reth_ethereum::provider::{ChangedAccount, ProviderFactory};
+use reth_ethereum::rpc::eth::StateCacheDb;
 use reth_ethereum::{
     BlockBody,
     chainspec::ChainSpecBuilder,
@@ -30,7 +42,7 @@ use reth_ethereum::{
     tasks::TokioTaskExecutor,
 };
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -51,19 +63,17 @@ static GLOBAL: Jemalloc = Jemalloc;
 struct Args {
     #[arg(long, help = "Path to the genesis JSON file")]
     chain: Option<PathBuf>,
+
+    #[arg(long, help = "Max batch size for txpool insertion")]
+    max_batch_size: Option<usize>,
 }
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     // increase the file descriptor limit so we can handle a lot of connections
     utils::increase_nofile_limit(1_000_000)?;
-    let args = Args::parse();
 
-    // This block provider implementation is used for testing purposes.
-    // NOTE: This also means that we don't have access to the blockchain and are not able to serve
-    // any requests for headers or bodies which can result in dropped connections initiated by
-    // remote or able to validate transaction against the latest state.
-    let client = NoopProvider::default();
+    let args = Args::parse();
 
     let chain_spec = if let Some(path) = args.chain {
         let genesis = fs::read_to_string(path)?;
@@ -72,10 +82,29 @@ async fn main() -> eyre::Result<()> {
         Arc::new(ChainSpecBuilder::mainnet().build())
     };
 
+    let db_path = Path::new("./data");
+    if !db_path.exists() {
+        fs::create_dir_all(db_path)?;
+    }
+    let db = Arc::new(init_db(db_path, DatabaseArguments::default())?);
+    let factory = ProviderFactory::<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>::new(
+        db.clone(),
+        chain_spec.clone(),
+        StaticFileProvider::read_write(db_path.join("static_files"))?,
+    );
+    init_genesis(&factory)?;
+
+    let client = BlockchainProvider::new(factory)?;
+
+    // This block provider implementation is used for testing purposes.
+    // NOTE: This also means that we don't have access to the blockchain and are not able to serve
+    // remote or able to validate transaction against the latest state.
+    // let client = NoopProvider::eth(chain_spec.clone());
+
     let blob_store = InMemoryBlobStore::default();
     let tx_validator =
         EthTransactionValidatorBuilder::new(client.clone()).build(blob_store.clone());
-
+    // let tx_validator = OkValidator::default();
     let pool: Pool<
         EthTransactionValidator<_, EthPooledTransaction>,
         CoinbaseTipOrdering<EthPooledTransaction>,
@@ -119,13 +148,19 @@ async fn main() -> eyre::Result<()> {
         .with_evm_config(eth_evm_config.clone())
         .with_consensus(EthBeaconConsensus::new(chain_spec.clone()));
 
-    let eth_api = EthApiBuilder::new(
+    let eth_api_builder = EthApiBuilder::new(
         client.clone(),
         pool.clone(),
         NoopNetwork::default(),
         eth_evm_config,
-    )
-    .build();
+    );
+
+    let eth_api = if let Some(batch_size) = args.max_batch_size {
+        eth_api_builder.max_batch_size(batch_size).build()
+    } else {
+        eth_api_builder.build()
+    };
+
     let config = TransportRpcModuleConfig::default().with_http([RethRpcModule::Eth]);
     let server = rpc_builder.build(config, eth_api);
 
@@ -206,7 +241,7 @@ async fn main() -> eyre::Result<()> {
                         changed_accounts.push(ChangedAccount {
                             address: sender,
                             nonce,
-                            balance: U256::from(nonce),
+                            balance: U256::MAX,
                         });
                     }
 


### PR DESCRIPTION
## Summary

This PR updates the txpool benchmark to use `EthTransactionValidator` instead of `OkValidator`, enabling full validation against a real `BlockchainProvider`. Changes include the following:

- Replaces `OkValidator` with `EthTransactionValidator` to bench validation against genesis state .
- Adds CLI args:  
  - `--chain`: optional path to a genesis JSON file  
  - `--max-batch-size`: optional batch size for txpool insertion  
- Temporarily updates `reth` dependencies to use a fork (`0xKitsune/reth`, rev `b7a3f06`) with batch txpool insertion support  